### PR TITLE
sanity check attestation challenge

### DIFF
--- a/app/src/main/java/com/google/attestationexample/AttestationTest.java
+++ b/app/src/main/java/com/google/attestationexample/AttestationTest.java
@@ -171,6 +171,9 @@ public class AttestationTest extends AsyncTask<Void, String, Void> {
         printKeyUsage(attestationCert);
 
         Attestation attestation = new Attestation(attestationCert);
+        if (!Arrays.equals(attestation.getAttestationChallenge(), challenge)) {
+            throw new GeneralSecurityException("challenge mismatch");
+        }
         publishProgress(attestation.toString() + "\n");
 
         Signature signer = Signature.getInstance("SHA256WithECDSA");


### PR DESCRIPTION
This makes the example a bit closer to real world usage where this would
be a random byte string provided by the server (or even another Android
device) performing the verification.